### PR TITLE
Update to work with Proton 5.13

### DIFF
--- a/protonhax
+++ b/protonhax
@@ -26,7 +26,7 @@ shift
 
 if [[ "$c" == "init" ]]; then
     mkdir -p $phd/$SteamAppId
-    printf "%s" "$1" > $phd/$SteamAppId/exe
+    printf "%s" "${@: -3:1}" > $phd/$SteamAppId/exe
     printf "%s" "$STEAM_COMPAT_DATA_PATH/pfx" > $phd/$SteamAppId/pfx
     env -0 > $phd/$SteamAppId/env
     "$@"


### PR DESCRIPTION
Previous proton versions would load the game calling the proton as first parameters.

Since the update for 5.13 it calls first SteamLinuxRuntime_soldier before running the game.

`/home/person/SteamLibrary/steamapps/common/SteamLinuxRuntime_soldier/_v2-entry-point --deploy=soldier --suite=soldier --verb=waitforexitandrun -- /home/person/SteamLibrary/steamapps/common/Proton 5.13/proton waitforexitandrun /home/person/SteamLibrary/steamapps/common/Game/game.exe`

So I changed from getting the first parameter to getting the third last.